### PR TITLE
0.1.2: Bug fix and /nss error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ compileJava {
     targetCompatibility = '1.8'
 }
 
-version = "0.1.1"
+version = "0.1.2"
 group= "dev.meyi.noscamspam"
 archivesBaseName = "NoScamSpam"
 

--- a/src/main/java/dev/meyi/noscamspam/NoScamSpam.java
+++ b/src/main/java/dev/meyi/noscamspam/NoScamSpam.java
@@ -22,7 +22,7 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 public class NoScamSpam {
 
   public static final String MODID = "NoScamSpam";
-  public static final String VERSION = "0.1.1";
+  public static final String VERSION = "0.1.2";
   public static final Gson gson = new Gson();
   public static final String PREFIX =
       EnumChatFormatting.BLACK + "[" + EnumChatFormatting.RED + "NSS"

--- a/src/main/java/dev/meyi/noscamspam/checks/UserCheck.java
+++ b/src/main/java/dev/meyi/noscamspam/checks/UserCheck.java
@@ -47,6 +47,6 @@ public class UserCheck {
       e.printStackTrace();
     }
 
-    return false;
+    return !NoScamSpam.config.showOnError;
   }
 }

--- a/src/main/java/dev/meyi/noscamspam/commands/NoScamSpamCommand.java
+++ b/src/main/java/dev/meyi/noscamspam/commands/NoScamSpamCommand.java
@@ -148,15 +148,27 @@ public class NoScamSpamCommand extends CommandBase {
               NoScamSpam.PREFIX + EnumChatFormatting.RED
                   + "Run /nss api (key) to set your api key. Do /api if you need to get your api key."));
         }
+      } else if (args.length == 1 && args[0].equalsIgnoreCase("error")) {
+        NoScamSpam.config.showOnError ^= true;
+        player.addChatMessage(new ChatComponentText(
+            NoScamSpam.PREFIX + (NoScamSpam.config.showOnError ? EnumChatFormatting.GREEN
+                : EnumChatFormatting.RED)
+                + "On API errors, the party invite will be " +
+                (NoScamSpam.config.showOnError ? EnumChatFormatting.DARK_GREEN
+                    + "" + EnumChatFormatting.BOLD + "SHOWN"
+                    : EnumChatFormatting.DARK_RED + "" + EnumChatFormatting.BOLD + "HIDDEN")
+        ));
       } else {
         player.addChatMessage(new ChatComponentText(
             NoScamSpam.PREFIX + EnumChatFormatting.GREEN + "Help\n" + EnumChatFormatting.DARK_GREEN
                 + EnumChatFormatting.BOLD
-                + " - " + EnumChatFormatting.GREEN + "bounds (skill|cata|network) (number)" + "\n"
+                + " - " + EnumChatFormatting.GREEN + "check (skill|cata|network) (number)" + "\n"
                 + EnumChatFormatting.DARK_GREEN + EnumChatFormatting.BOLD
                 + " - " + EnumChatFormatting.GREEN + "whitelist (add|remove|reset) (username)"
                 + "\n" + EnumChatFormatting.DARK_GREEN + EnumChatFormatting.BOLD
-                + " - " + EnumChatFormatting.GREEN + "api (key)"));
+                + " - " + EnumChatFormatting.GREEN + "api (key)"
+                + "\n" + EnumChatFormatting.DARK_GREEN + EnumChatFormatting.BOLD
+                + " - " + EnumChatFormatting.GREEN + "error"));
       }
     }
   }

--- a/src/main/java/dev/meyi/noscamspam/json/Config.java
+++ b/src/main/java/dev/meyi/noscamspam/json/Config.java
@@ -12,6 +12,7 @@ public class Config {
   public int catacombsLevel;
 
   public List<String> whitelist;
+  public boolean showOnError = true;
 
   public Config() {
     apiKey = "";


### PR DESCRIPTION
Goal of `/nss error` is to hide party requests that happen to lead to a failed api request. This might unintentionally hide real parties, but you could always do /party accept (username) if you know the party is coming.


